### PR TITLE
query_status_fix

### DIFF
--- a/src/jag-vips-client/src/main/java/ca/bc/gov/open/jagvipsclient/prohibition/ProhibitionService.java
+++ b/src/jag-vips-client/src/main/java/ca/bc/gov/open/jagvipsclient/prohibition/ProhibitionService.java
@@ -9,6 +9,6 @@ package ca.bc.gov.open.jagvipsclient.prohibition;
  */
 public interface ProhibitionService {
 
-     VipsProhibitionStatusResponse getVipsProhibitionStatus(Long prohibitionId);
+     VipsProhibitionStatusResponse getVipsProhibitionStatus(String prohibitionId);
 
 }

--- a/src/jag-vips-client/src/main/java/ca/bc/gov/open/jagvipsclient/prohibition/ProhibitionServiceImpl.java
+++ b/src/jag-vips-client/src/main/java/ca/bc/gov/open/jagvipsclient/prohibition/ProhibitionServiceImpl.java
@@ -25,14 +25,12 @@ public class ProhibitionServiceImpl implements ProhibitionService{
     }
 
 	@Override
-	public VipsProhibitionStatusResponse getVipsProhibitionStatus(Long prohibitionNoticeNo) {
+	public VipsProhibitionStatusResponse getVipsProhibitionStatus(String prohibitionNoticeNo) {
 		
 		 try {
 			 
-			 String noticeNo = Long.toString(prohibitionNoticeNo);
-			 
 			 // Here what we're doing is a conversion from the actual response to a properly camelCased JSON response.  
-			 VipsProhibitionStatusOrdsResponse response = this.prohibStatusApi.prohibitionStatusNoticeNoGet(noticeNo);
+			 VipsProhibitionStatusOrdsResponse response = this.prohibStatusApi.prohibitionStatusNoticeNoGet(prohibitionNoticeNo);
 			 
 			 ProhibitionStatus status = new ProhibitionStatus();
 			 


### PR DESCRIPTION
Changed prohibition notice number from Long type to string to fix "Not found" issue.