### PR TITLE
Update Swagger YML requests and responses to match ORDS inputs and re…

### DIFF
--- a/src/jag-vips-client/vipsords.yaml
+++ b/src/jag-vips-client/vipsords.yaml
@@ -229,12 +229,6 @@ paths:
 definitions:
   healthOrdsResponse:
     type: object
-    required:
-    - appid
-    - method
-    - status
-    - host
-    - instance
     properties:
       appid:
         type: string
@@ -248,10 +242,6 @@ definitions:
         type: string
   vipsDocumentOrdsResponse:
     type: object
-    required:
-    - document_id
-    - status_code
-    - status_message
     properties:
       document_id:
         type: string
@@ -261,16 +251,6 @@ definitions:
         type: string
   vipsProhibitionStatusOrdsResponse:
     type: object
-    required: 
-    - status_code
-    - status_message
-    - notice_type_cd
-    - notice_served_dt
-    - review_form_submitted_yn
-    - review_created_yn
-    - original_cause
-    - surname_nm
-    - driver_licence_seized_yn
     properties:
       status_code:
         type: string
@@ -318,9 +298,6 @@ definitions:
               type: string
   vipsDisclosureSentOrdsRequest:
     type: object
-    required:
-    - user_id
-    - disclosure_dtm
     properties:
       disclosure_dtm:
         type: string
@@ -328,10 +305,6 @@ definitions:
         type: string
   vipsDisclosureSentOrdsResponse:
     type: object
-    required:
-    - status_code
-    - status_message
-    - upd_dtm
     properties:
       status_code:
         type: string
@@ -341,9 +314,6 @@ definitions:
         type: string        
   errorMessage:
     type: object
-    required:
-    - status_code
-    - status_message
     properties:
       status_code:
         type: string


### PR DESCRIPTION
1)  remove required fields so all the properties can be null
2)  /disclosure/{documentId}/{authGuid} is only the endpoint that returns does not return status_code, status_message on response '200',  but I have tested both the positive case https://wsgw.dev.jag.gov.bc.ca/rdfpvips/ords/devh/vipsords/web/disclosure/3243/DIGITALFORMGUID and a bad case.  Both work.